### PR TITLE
README has been renamed to README.rst

### DIFF
--- a/dot_parser.py
+++ b/dot_parser.py
@@ -413,7 +413,7 @@ def graph_definition():
         
         identifier = Word(alphanums + "_." ).setName("identifier")
         
-        double_quoted_string = QuotedString('"', multiline=True, unquoteResults=False) # dblQuotedString
+        double_quoted_string = QuotedString('"', multiline=True, escChar='\\', unquoteResults=False) # dblQuotedString
 
         alphastring_ = OneOrMore(CharsNotIn(_noncomma + ' '))
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ config = dict(
         'Topic :: Software Development :: Libraries :: Python Modules'],
     py_modules = ['pydot', 'dot_parser'],
     install_requires = ['pyparsing', 'setuptools'],
-    data_files = [('.', ['LICENSE', 'README'])])
+    data_files = [('.', ['LICENSE', 'README.rst'])])
 
 
 if sys.version_info >= (3,):


### PR DESCRIPTION
Since README was renamed README.rst in commit 77266a526874173995833a4afe431fa9561a35dd it is no longer possible to install via setup.py (or via for example pypi2rpm.py which we use)

Without this fix, installing fails with:

```
(test): lapetus pydot \$ ; python setup.py install
running install
running bdist_egg
running egg_info
creating pydot2.egg-info
writing requirements to pydot2.egg-info/requires.txt
writing pydot2.egg-info/PKG-INFO
writing top-level names to pydot2.egg-info/top_level.txt
writing dependency_links to pydot2.egg-info/dependency_links.txt
writing manifest file 'pydot2.egg-info/SOURCES.txt'
reading manifest file 'pydot2.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pydot2.egg-info/SOURCES.txt'
installing library code to build/bdist.macosx-10.6-intel/egg
running install_lib
running build_py
creating build
creating build/lib
copying pydot.py -> build/lib
copying dot_parser.py -> build/lib
creating build/bdist.macosx-10.6-intel
creating build/bdist.macosx-10.6-intel/egg
copying build/lib/dot_parser.py -> build/bdist.macosx-10.6-intel/egg
copying build/lib/pydot.py -> build/bdist.macosx-10.6-intel/egg
byte-compiling build/bdist.macosx-10.6-intel/egg/dot_parser.py to dot_parser.pyc
byte-compiling build/bdist.macosx-10.6-intel/egg/pydot.py to pydot.pyc
installing package data to build/bdist.macosx-10.6-intel/egg
running install_data
copying LICENSE -> build/bdist.macosx-10.6-intel/egg/.
error: can't copy 'README': doesn't exist or not a regular file
(test): lapetus pydot \$ ;
```

With this fix, the installer works as expected:

```
(test): lapetus pydot \$ ; python setup.py install
running install
running bdist_egg
running egg_info
writing requirements to pydot2.egg-info/requires.txt
writing pydot2.egg-info/PKG-INFO
writing top-level names to pydot2.egg-info/top_level.txt
writing dependency_links to pydot2.egg-info/dependency_links.txt
reading manifest file 'pydot2.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pydot2.egg-info/SOURCES.txt'
installing library code to build/bdist.macosx-10.6-intel/egg
running install_lib
running build_py
installing package data to build/bdist.macosx-10.6-intel/egg
running install_data
copying README.rst -> build/bdist.macosx-10.6-intel/egg/.
creating build/bdist.macosx-10.6-intel/egg/EGG-INFO
copying pydot2.egg-info/PKG-INFO -> build/bdist.macosx-10.6-intel/egg/EGG-INFO
copying pydot2.egg-info/SOURCES.txt -> build/bdist.macosx-10.6-intel/egg/EGG-INFO
copying pydot2.egg-info/dependency_links.txt -> build/bdist.macosx-10.6-intel/egg/EGG-INFO
copying pydot2.egg-info/requires.txt -> build/bdist.macosx-10.6-intel/egg/EGG-INFO
copying pydot2.egg-info/top_level.txt -> build/bdist.macosx-10.6-intel/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
creating dist
creating 'dist/pydot2-1.0.32-py2.7.egg' and adding 'build/bdist.macosx-10.6-intel/egg' to it
removing 'build/bdist.macosx-10.6-intel/egg' (and everything under it)
Processing pydot2-1.0.32-py2.7.egg
Copying pydot2-1.0.32-py2.7.egg to /Users/mattiasa/.virtualenvs/test/lib/python2.7/site-packages
Adding pydot2 1.0.32 to easy-install.pth file

Installed /Users/mattiasa/.virtualenvs/test/lib/python2.7/site-packages/pydot2-1.0.32-py2.7.egg
Processing dependencies for pydot2==1.0.32
Searching for pyparsing
Reading http://pypi.python.org/simple/pyparsing/
Reading http://pyparsing.sourceforge.net/
Reading http://pyparsing.wikispaces.com/
Reading http://sourceforge.net/project/showfiles.php?group_id=97203
Reading http://sourceforge.net/projects/pyparsing
Best match: pyparsing 2.0.2
Downloading https://pypi.python.org/packages/source/p/pyparsing/pyparsing-2.0.2.zip#md5=e0e49d73cfb9e79954b4a1c553dfae44
Processing pyparsing-2.0.2.zip
Running pyparsing-2.0.2/setup.py -q bdist_egg --dist-dir /var/folders/n2/_w0226gs4b73v9yqgrzs796w0000gn/T/easy_install-BO_WIw/pyparsing-2.0.2/egg-dist-tmp-sh4GYr
zip_safe flag not set; analyzing archive contents...
pyparsing: module MAY be using inspect.stack
Adding pyparsing 2.0.2 to easy-install.pth file

Installed /Users/mattiasa/.virtualenvs/test/lib/python2.7/site-packages/pyparsing-2.0.2-py2.7.egg
Searching for setuptools==0.6c11
Best match: setuptools 0.6c11
Processing setuptools-0.6c11-py2.7.egg
setuptools 0.6c11 is already the active version in easy-install.pth
Installing easy_install script to /Users/mattiasa/.virtualenvs/test/bin
Installing easy_install-2.7 script to /Users/mattiasa/.virtualenvs/test/bin

Using /Users/mattiasa/.virtualenvs/test/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg
Finished processing dependencies for pydot2==1.0.32
(test): lapetus pydot \$ ; 
```
