### PR TITLE
replace file() by open() as recommended for python3

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -228,7 +228,7 @@ def graph_from_dot_file(path):
     representing the graph.
     """
 
-    fd = file(path, 'rb')
+    fd = open(path, 'rb')
     data = fd.read()
     fd.close()
 
@@ -1892,7 +1892,7 @@ class Dot(Graph):
         if prog is None:
             prog = self.prog
 
-        dot_fd = file(path, "w+b")
+        dot_fd = open(path, "w+b")
         if format == 'raw':
             data = self.to_string()
             if isinstance(data, basestring):
@@ -1972,13 +1972,13 @@ class Dot(Graph):
 
             # Get its data
             #
-            f = file(img, 'rb')
+            f = open(img, 'rb')
             f_data = f.read()
             f.close()
 
             # And copy it under a file with the same name in the temporary directory
             #
-            f = file( os.path.join( tmp_dir, os.path.basename(img) ), 'wb' )
+            f = open( os.path.join( tmp_dir, os.path.basename(img) ), 'wb' )
             f.write(f_data)
             f.close()
 


### PR DESCRIPTION
Python 3 (at least 3.4) doesn't even have the file() constructor available, so pydot2 cannot write to files in Python 3. Open should be used, as recommended.