### PR TITLE
Updated byte string syntax for python-3.x compat

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -2000,7 +2000,7 @@ class Dot(Graph):
             stdout_output.append(data)
         stdout.close()
 
-        stdout_output = ''.join(stdout_output)
+        stdout_output = b''.join(stdout_output)
 
         if not stderr.closed:
             stderr_output = list()


### PR DESCRIPTION
Python 3 must use byte string to join list of other byte strings.
